### PR TITLE
[SQL-DS-CACHE-52][POAE7-947] PreBuffer parquet row groups in native reader

### DIFF
--- a/oap-ape/ape-java/ape-common/src/main/java/com/intel/ape/ParquetReaderJNI.java
+++ b/oap-ape/ape-java/ape-common/src/main/java/com/intel/ape/ParquetReaderJNI.java
@@ -29,13 +29,14 @@ public class ParquetReaderJNI {
   public static long init(String fileName, String hdfsHost, int hdfsPort, String requiredSchema,
                           int firstRowGroupIndex, int totalGroupToRead) {
     return init(fileName, hdfsHost, hdfsPort, requiredSchema,
-            firstRowGroupIndex, totalGroupToRead, false);
+            firstRowGroupIndex, totalGroupToRead, false, false);
   }
 
   // return a reader pointer
   public static native long init(String fileName, String hdfsHost, int hdfsPort,
                                  String requiredSchema, int firstRowGroupIndex,
-                                 int totalGroupToRead, boolean plasmaCacheEnabled);
+                                 int totalGroupToRead, boolean plasmaCacheEnabled,
+                                 boolean preBufferEnabled);
 
   public static native int readBatch(long reader, int batchSize, long[] buffers, long[] nulls);
 

--- a/oap-ape/ape-java/ape-flink/pom.xml
+++ b/oap-ape/ape-java/ape-flink/pom.xml
@@ -210,7 +210,7 @@
                   <shadeTestJar>false</shadeTestJar>
                   <artifactSet>
                     <includes combine.children="append">
-                      <include>com.intel.oap:oap-common</include>
+                      <include>com.intel.oap:pmem-common</include>
                       <include>com.intel.oap:ape-common</include>
                       <include>com.intel.oap:ape-hcfs</include>
                       <include>com.fasterxml.jackson.core:jackson-core</include>

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/utils/ParquetNativeRecordReaderWrapper.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/utils/ParquetNativeRecordReaderWrapper.java
@@ -106,8 +106,11 @@ public class ParquetNativeRecordReaderWrapper {
         ConvertToJson message = new ConvertToJson(fieldTypeList, projectedFields);
         boolean plasmaCacheEnabled =
                 hadoopConfig.getBoolean("fs.ape.reader.plasmaCacheEnabled", false);
+        boolean preBufferEnabled =
+                hadoopConfig.getBoolean("fs.ape.reader.preBufferEnabled", false);
         reader = ParquetReaderJNI.init(fileName, hdfsHost, hdfsPort, message.toJson(),
-                inputSplitRowGroupStartIndex, inputSplitRowGroupNum, plasmaCacheEnabled);
+                inputSplitRowGroupStartIndex, inputSplitRowGroupNum, plasmaCacheEnabled,
+                preBufferEnabled);
 
         boolean cacheLocalityEnabled =
                 hadoopConfig.getBoolean("fs.ape.reader.cacheLocalityEnabled", false);
@@ -122,8 +125,8 @@ public class ParquetNativeRecordReaderWrapper {
                             Constants.DEFAULT_REDIS_AUTH));
         }
 
-        LOG.info("native parquet reader initialized, plasma cache: {}, cache locality: {}",
-                plasmaCacheEnabled, cacheLocalityEnabled);
+        LOG.info("native parquet reader initialized, plasma cache: {}, cache locality: {}, prebuffer: {}",
+                plasmaCacheEnabled, cacheLocalityEnabled, preBufferEnabled);
 
         return reader;
 

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/utils/ParquetNativeRecordReaderWrapper.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/utils/ParquetNativeRecordReaderWrapper.java
@@ -125,7 +125,8 @@ public class ParquetNativeRecordReaderWrapper {
                             Constants.DEFAULT_REDIS_AUTH));
         }
 
-        LOG.info("native parquet reader initialized, plasma cache: {}, cache locality: {}, prebuffer: {}",
+        LOG.info("native parquet reader initialized, plasma cache: {},  "
+                        + "cache locality: {}, pre buffer: {}",
                 plasmaCacheEnabled, cacheLocalityEnabled, preBufferEnabled);
 
         return reader;

--- a/oap-ape/ape-java/ape-spark/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetNativeRecordReaderWrapper.java
+++ b/oap-ape/ape-java/ape-spark/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetNativeRecordReaderWrapper.java
@@ -87,7 +87,7 @@ public class ParquetNativeRecordReaderWrapper extends RecordReader<Void, Object>
     LOG.info("filename is " + fileName + " hdfs is " + hdfsHost + " " + hdfsPort);
     LOG.info("schema is " + sparkSchema.json());
     reader = ParquetReaderJNI.init(fileName, hdfsHost, hdfsPort, sparkSchema.json(),
-            inputSplitRowGroupStartIndex, inputSplitRowGroupNum, cacheEnabled);
+            inputSplitRowGroupStartIndex, inputSplitRowGroupNum, cacheEnabled, false);
   }
 
   public void getRequiredSplitRowGroup(ParquetInputSplit split, Configuration configuration)

--- a/oap-ape/ape-native/src/CMakeLists.txt
+++ b/oap-ape/ape-native/src/CMakeLists.txt
@@ -72,6 +72,7 @@ set(AGG_SRC utils/AggExpression.cc)
 set(PARSE_TEST utils/convertorTest.cc)
 set(AGG_PARSE_TEST utils/aggParserTest.cc)
 set(DECIMAL_TEST utils/decimalTest.cc)
+set(PLASMA_TEST utils/plasmaTest.cc)
 
 file(GLOB JNI_LIB_SRC
     com_intel_ape_ParquetReaderJNI.cc reader.cc)
@@ -87,6 +88,7 @@ add_library(parse SHARED ${PARSE_SRC} ${DECIMAL_SRC} ${AGG_SRC})
 add_executable(parse_test ${PARSE_SRC} ${PARSE_TEST})
 add_executable(agg_parse_test ${PARSE_SRC} ${AGG_SRC} ${AGG_PARSE_TEST})
 add_executable(decimal_test ${DECIMAL_TEST})
+add_executable(plasma_test ${PLASMA_TEST})
 
 add_compile_options("-I$ENV{JAVA_HOME}/include/")
 add_compile_options("-I$ENV{JAVA_HOME}/include/linux")
@@ -101,4 +103,5 @@ target_link_libraries(parse nlohmann_json::nlohmann_json ${ARROW_LIB})
 target_link_libraries(parse_test parse)
 target_link_libraries(agg_parse_test parse)
 target_link_libraries(decimal_test ${ARROW_LIB} parquet_jni)
+target_link_libraries(plasma_test parquet_jni)
 

--- a/oap-ape/ape-native/src/com_intel_ape_ParquetReaderJNI.cc
+++ b/oap-ape/ape-native/src/com_intel_ape_ParquetReaderJNI.cc
@@ -21,11 +21,12 @@
 JNIEXPORT jlong JNICALL Java_com_intel_ape_ParquetReaderJNI_init(
     JNIEnv* env, jclass cls, jstring fileName, jstring hdfsHost, jint hdfsPort,
     jstring requiredSchema, jint firstRowGroup, jint rowGroupToRead,
-    jboolean plasmaCacheEnabled) {
+    jboolean plasmaCacheEnabled, jboolean preBufferEnabled) {
   int i = 0;
   ape::Reader* reader = new ape::Reader();
 
   reader->setPlasmaCacheEnabled(plasmaCacheEnabled);
+  reader->setPreBufferEnabled(preBufferEnabled);
 
   std::string schema_ = env->GetStringUTFChars(requiredSchema, nullptr);
   std::string fileName_ = env->GetStringUTFChars(fileName, nullptr);

--- a/oap-ape/ape-native/src/com_intel_ape_ParquetReaderJNI.h
+++ b/oap-ape/ape-native/src/com_intel_ape_ParquetReaderJNI.h
@@ -27,11 +27,12 @@ extern "C" {
 /*
  * Class:     com_intel_ape_ParquetReaderJNI
  * Method:    init
- * Signature: (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;IIZ)J
+ * Signature: (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;IIZZ)J
  */
 JNIEXPORT jlong JNICALL Java_com_intel_ape_ParquetReaderJNI_init(JNIEnv*, jclass, jstring,
                                                                  jstring, jint, jstring,
-                                                                 jint, jint, jboolean);
+                                                                 jint, jint, jboolean,
+                                                                 jboolean);
 
 /*
  * Class:     com_intel_ape_ParquetReaderJNI

--- a/oap-ape/ape-native/src/reader.cc
+++ b/oap-ape/ape-native/src/reader.cc
@@ -77,19 +77,12 @@ void Reader::init(std::string fileName, std::string hdfsHost, int hdfsPort,
 
   currentRowGroup = firstRowGroupIndex;
 
-  rowGroupReaders.resize(totalRowGroups);
-  for (int i = 0; i < totalRowGroups; i++) {
-    rowGroupReaders[i] = parquetReader->RowGroup(firstRowGroupIndex + i);
-    totalRows += rowGroupReaders[i]->metadata()->num_rows();
-    ARROW_LOG(DEBUG) << "this rg have rows: "
-                     << rowGroupReaders[i]->metadata()->num_rows();
-  }
   columnReaders.resize(requiredColumnIndex.size());
   initRequiredColumnCount = requiredColumnIndex.size();
   initPlusFilterRequiredColumnCount = initRequiredColumnCount;
   ARROW_LOG(DEBUG) << "initRequiredColumnCount is " << initRequiredColumnCount;
 
-  ARROW_LOG(INFO) << "init done, totalRows " << totalRows;
+  ARROW_LOG(INFO) << "init done, totalRowGroups " << totalRowGroups;
 }
 
 void Reader::initCacheManager(std::string fileName, std::string hdfsHost, int hdfsPort) {
@@ -144,6 +137,14 @@ void convertBitMap(uint8_t* srcBitMap, uint8_t* dstByteMap, int len) {
 }
 
 int Reader::readBatch(int32_t batchSize, int64_t* buffersPtr_, int64_t* nullsPtr_) {
+  // Pre buffer row groups.
+  // This is not called in `init` because `requiredColumnIndex`
+  // may be changed by `setFilter` after `init`.
+  preBufferRowGroups();
+  // Init grow group readers.
+  // This should be called after preBufferRowGroups
+  initRowGroupReaders();
+
   // this reader have read all rows
   if (totalRowsRead >= totalRows) {
     return -1;
@@ -359,8 +360,8 @@ bool Reader::skipNextRowGroup() {
 void Reader::close() {
   ARROW_LOG(INFO) << "Filter takes " << time.count() * 1000 << " ms.";
 
-  ARROW_LOG(INFO) << "close reader.";
-  parquetReader->Close();
+  // No need to call parquetReader->Close(). It will be done in destructor.
+
   file->Close();
   for (auto ptr : extraByteArrayBuffers) {
     delete[] ptr;
@@ -375,6 +376,45 @@ void Reader::close() {
   // delete options;
 }
 
+void Reader::preBufferRowGroups() {
+  if (currentBufferedRowGroup >= currentRowGroup) {
+    return;
+  }
+
+  int maxBufferCount = 100;  // TODO
+  std::vector<int> rowGroups;
+  std::vector<int> columns = requiredColumnIndex;
+  int maxRowGroupIndex = firstRowGroupIndex + totalRowGroups - 1;
+  for (int i = 0; i < maxBufferCount && currentBufferedRowGroup < maxRowGroupIndex; i++) {
+    currentBufferedRowGroup = currentRowGroup + i;
+    rowGroups.push_back(currentBufferedRowGroup);
+  }
+
+  ::arrow::io::AsyncContext ctx;
+  ::arrow::io::CacheOptions options = ::arrow::io::CacheOptions::Defaults();
+
+  if (rowGroups.size() > 0) {
+    ARROW_LOG(INFO) << "PreBuffer, " << rowGroups.size() << " row group(s), "
+                    << columns.size() << " columns in each group";
+
+    parquetReader->PreBuffer(rowGroups, columns, ctx, options);
+  }
+}
+
+void Reader::initRowGroupReaders() {
+  if (rowGroupReaders.size() > 0) {
+    return;
+  }
+
+  rowGroupReaders.resize(totalRowGroups);
+  for (int i = 0; i < totalRowGroups; i++) {
+    rowGroupReaders[i] = parquetReader->RowGroup(firstRowGroupIndex + i);
+    totalRows += rowGroupReaders[i]->metadata()->num_rows();
+    ARROW_LOG(DEBUG) << "this rg have rows: "
+                     << rowGroupReaders[i]->metadata()->num_rows();
+  }
+}
+
 void Reader::checkEndOfRowGroup() {
   if (totalRowsRead != totalRowsLoadedSoFar) return;
   // if a splitFile contains rowGroup [2,5], currentRowGroup is 2
@@ -383,10 +423,8 @@ void Reader::checkEndOfRowGroup() {
   currentRowGroup++;
   totalRowGroupsRead++;
 
-  // relase objects in previous row group
-  if (plasmaCacheManager) {
-    plasmaCacheManager->release();
-  }
+  // Do not release CacheManager's objects when going to next row group.
+  // release() may free all useful buffers loaded by preBufferRowGroups.
 
   for (int i = 0; i < requiredColumnIndex.size(); i++) {
     columnReaders[i] = rowGroupReader->Column(requiredColumnIndex[i]);

--- a/oap-ape/ape-native/src/reader.h
+++ b/oap-ape/ape-native/src/reader.h
@@ -63,6 +63,10 @@ class Reader {
  private:
   void convertSchema(std::string requiredColumnName);
 
+  void preBufferRowGroups();
+
+  void initRowGroupReaders();
+
   void checkEndOfRowGroup();
 
   void setFilterColumnNames(std::shared_ptr<Expression> filter);
@@ -123,5 +127,6 @@ class Reader {
   bool plasmaCacheEnabled = false;
   std::shared_ptr<PlasmaCacheManager> plasmaCacheManager;
   std::shared_ptr<sw::redis::ConnectionOptions> redisConnectionOptions;
+  int currentBufferedRowGroup = -1;
 };
 }  // namespace ape

--- a/oap-ape/ape-native/src/reader.h
+++ b/oap-ape/ape-native/src/reader.h
@@ -60,6 +60,8 @@ class Reader {
 
   void setPlasmaCacheRedis(std::string host, int port, std::string password);
 
+  void setPreBufferEnabled(bool isEnabled);
+
  private:
   void convertSchema(std::string requiredColumnName);
 
@@ -125,8 +127,10 @@ class Reader {
   std::vector<std::vector<ApeDecimal128Ptr>> aggResults;
 
   bool plasmaCacheEnabled = false;
-  std::shared_ptr<PlasmaCacheManager> plasmaCacheManager;
+  std::shared_ptr<PlasmaCacheManagerProvider> plasmaCacheManagerProvider;
   std::shared_ptr<sw::redis::ConnectionOptions> redisConnectionOptions;
+
+  bool preBufferEnabled = false;
   int currentBufferedRowGroup = -1;
 };
 }  // namespace ape

--- a/oap-ape/ape-native/src/utils/PlasmaCacheManager.cc
+++ b/oap-ape/ape-native/src/utils/PlasmaCacheManager.cc
@@ -98,7 +98,10 @@ void PlasmaCacheManager::setCacheInfoToRedis() {
         std::string member = buff;
         scores.insert({member, range.offset});
       }
-      redis_->zadd(file_path_, scores.begin(), scores.end());
+
+      if (scores.size() > 0) {
+        redis_->zadd(file_path_, scores.begin(), scores.end());
+      }
 
       cache_hit_count_ = 0;
       cache_miss_count_ = 0;

--- a/oap-ape/ape-native/src/utils/PlasmaCacheManager.cc
+++ b/oap-ape/ape-native/src/utils/PlasmaCacheManager.cc
@@ -170,7 +170,7 @@ std::shared_ptr<Buffer> PlasmaCacheManager::getFileRange(::arrow::io::ReadRange 
   std::vector<plasma::ObjectBuffer> obufs(1);
 
   arrow::Status status = client_->Get(oids.data(), 1, -1, obufs.data());
-   if (!status.ok() || obufs[0].data == nullptr) {
+  if (!status.ok() || obufs[0].data == nullptr) {
     ARROW_LOG(WARNING) << "plasma, Get failed: " << status.message();
     cache_miss_count_ += 1;
     return nullptr;
@@ -262,7 +262,7 @@ bool PlasmaCacheManager::deleteFileRange(::arrow::io::ReadRange range) {
 }
 
 PlasmaCacheManagerProvider::PlasmaCacheManagerProvider(std::string file_path)
-  : file_path_(file_path) {
+    : file_path_(file_path) {
   auto default_manager = std::make_shared<PlasmaCacheManager>(file_path);
   managers_.push_back(default_manager);
 }
@@ -275,12 +275,10 @@ void PlasmaCacheManagerProvider::close() {
   }
 }
 
-bool PlasmaCacheManagerProvider::connected() {
-  return managers_[0]->connected();
-}
+bool PlasmaCacheManagerProvider::connected() { return managers_[0]->connected(); }
 
-
-void PlasmaCacheManagerProvider::setCacheRedis(std::shared_ptr<sw::redis::ConnectionOptions> options) {
+void PlasmaCacheManagerProvider::setCacheRedis(
+    std::shared_ptr<sw::redis::ConnectionOptions> options) {
   redis_options_ = options;
 
   for (auto manager : managers_) {

--- a/oap-ape/ape-native/src/utils/PlasmaCacheManager.h
+++ b/oap-ape/ape-native/src/utils/PlasmaCacheManager.h
@@ -74,7 +74,6 @@ class PlasmaCacheManagerProvider : public parquet::CacheManagerProvider {
   std::string file_path_;
   std::vector<std::shared_ptr<PlasmaCacheManager>> managers_;
   std::shared_ptr<sw::redis::ConnectionOptions> redis_options_;
-
 };
 
 }  // namespace ape

--- a/oap-ape/ape-native/src/utils/PlasmaCacheManager.h
+++ b/oap-ape/ape-native/src/utils/PlasmaCacheManager.h
@@ -58,4 +58,23 @@ class PlasmaCacheManager : public parquet::CacheManager {
   std::vector<::arrow::io::ReadRange> cached_ranges_;
 };
 
+class PlasmaCacheManagerProvider : public parquet::CacheManagerProvider {
+ public:
+  explicit PlasmaCacheManagerProvider(std::string file_path);
+  ~PlasmaCacheManagerProvider();
+  void close();
+  bool connected();
+  void setCacheRedis(std::shared_ptr<sw::redis::ConnectionOptions> options);
+
+  // override methods
+  std::shared_ptr<parquet::CacheManager> defaultCacheManager() override;
+  std::shared_ptr<parquet::CacheManager> newCacheManager() override;
+
+ private:
+  std::string file_path_;
+  std::vector<std::shared_ptr<PlasmaCacheManager>> managers_;
+  std::shared_ptr<sw::redis::ConnectionOptions> redis_options_;
+
+};
+
 }  // namespace ape

--- a/oap-ape/ape-native/src/utils/PlasmaCacheManager.h
+++ b/oap-ape/ape-native/src/utils/PlasmaCacheManager.h
@@ -30,19 +30,19 @@ class PlasmaCacheManager : public parquet::CacheManager {
   bool connected();
   void close();
   void release();
-  plasma::ObjectID objectIdOfColumnChunk(::arrow::io::ReadRange range);
+  plasma::ObjectID objectIdOfFileRange(::arrow::io::ReadRange range);
 
   void setCacheRedis(std::shared_ptr<sw::redis::ConnectionOptions> options);
 
   // override methods
-  bool containsColumnChunk(::arrow::io::ReadRange range) override;
-  std::shared_ptr<Buffer> getColumnChunk(::arrow::io::ReadRange range) override;
-  bool cacheColumnChunk(::arrow::io::ReadRange range,
-                        std::shared_ptr<Buffer> data) override;
-  bool deleteColumnChunk(::arrow::io::ReadRange range) override;
+  bool containsFileRange(::arrow::io::ReadRange range) override;
+  std::shared_ptr<Buffer> getFileRange(::arrow::io::ReadRange range) override;
+  bool cacheFileRange(::arrow::io::ReadRange range,
+                      std::shared_ptr<Buffer> data) override;
+  bool deleteFileRange(::arrow::io::ReadRange range) override;
 
  protected:
-  std::string cacheKeyofColumnChunk(::arrow::io::ReadRange range);
+  std::string cacheKeyofFileRange(::arrow::io::ReadRange range);
   void setCacheInfoToRedis();
 
  private:

--- a/oap-ape/ape-native/src/utils/plasmaTest.cc
+++ b/oap-ape/ape-native/src/utils/plasmaTest.cc
@@ -2,11 +2,10 @@
 
 #include "PlasmaCacheManager.h"
 
-
 int main() {
-  auto file = 
-    "hdfs://sr490:9000/tpch_1t_snappy/lineitem/"
-    "part-00036-01f81a98-e2b0-4bd4-9134-62fd522bc891-c000.snappy.parquet";
+  auto file =
+      "hdfs://sr490:9000/tpch_1t_snappy/lineitem/"
+      "part-00036-01f81a98-e2b0-4bd4-9134-62fd522bc891-c000.snappy.parquet";
 
   ape::PlasmaCacheManager cacheManager(file);
   auto range = arrow::io::ReadRange();

--- a/oap-ape/ape-native/src/utils/plasmaTest.cc
+++ b/oap-ape/ape-native/src/utils/plasmaTest.cc
@@ -1,0 +1,22 @@
+#include <iostream>
+
+#include "PlasmaCacheManager.h"
+
+
+int main() {
+  auto file = 
+    "hdfs://sr490:9000/tpch_1t_snappy/lineitem/"
+    "part-00036-01f81a98-e2b0-4bd4-9134-62fd522bc891-c000.snappy.parquet";
+
+  ape::PlasmaCacheManager cacheManager(file);
+  auto range = arrow::io::ReadRange();
+  range.offset = 587558587;
+  range.length = 19723749;
+
+  auto c = cacheManager.containsFileRange(range);
+
+  std::cout << "contains: " << c << std::endl;
+
+  auto g = cacheManager.getFileRange(range);
+  std::cout << "is null: " << (g == nullptr) << std::endl;
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

* pre-load column chunks **asynchronously** with `ParquetFileReader::PreBuffer()` which has been optimized with `CacheManager` in https://github.com/oap-project/arrow/pull/6
* Change function names of `PlasmaCacheManager` to adapt changes in arrow project
* Optimize `close` and `release` objects



## How was this patch tested?
 integration tests

