### PR TITLE
[SQL-DS-CACHE-78][POAE7-1017] close inputstreams in flink wrapper to fix resource leak

### DIFF
--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/utils/ParquetNativeRecordReaderWrapper.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/utils/ParquetNativeRecordReaderWrapper.java
@@ -143,6 +143,7 @@ public class ParquetNativeRecordReaderWrapper {
         InputStream footerBytesStream = getFooterBytesStream(split, configuration);
         filterFileMetaDataByMidpoint(readFileMetaData(footerBytesStream),
                 splitStart, splitStart + splitSize);
+        footerBytesStream.close();
     }
 
     private InputStream getFooterBytesStream(FileSourceSplit split,
@@ -181,6 +182,7 @@ public class ParquetNativeRecordReaderWrapper {
         f.seek(footerIndex);
         ByteBuffer footerBytesBuffer = ByteBuffer.allocate(footerLength);
         f.readFully(footerBytesBuffer);
+        f.close();
         LOG.debug("Finished to read all footer bytes.");
         footerBytesBuffer.flip();
         InputStream footerBytesStream = ByteBufferInputStream.wrap(footerBytesBuffer);


### PR DESCRIPTION
## What changes were proposed in this pull request?

* fix a bug in Flink's native wrapper in which hdfs connecting ports are not released


## How was this patch tested?

integration tests,



