### PR TITLE
[SQL-DS-CACHE-89][POAE7-1016] Fix agg result when column value could be null

### DIFF
--- a/oap-ape/ape-native/src/utils/DecimalConvertor.h
+++ b/oap-ape/ape-native/src/utils/DecimalConvertor.h
@@ -43,11 +43,13 @@ struct DecimalVector {
   int32_t precision;
   int32_t scale;
   ResultType type;
+  std::shared_ptr<std::vector<uint8_t>> nullVector = nullptr;
   void operator=(const DecimalVector& lhs) {
     this->data = lhs.data;
     this->precision = lhs.precision;
     this->scale = lhs.scale;
     this->type = lhs.type;
+    this->nullVector = lhs.nullVector;
   }
 };
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix agg result when column value could be null, previous behavior will evaluate this null value.

## How was this patch tested?

 manual tests, for a column which data could be null, `select count(*), count(column_name) from table` result would be different.

