### PR TITLE
[SQL-DS-CACHE-95]check mid point of a parquet row group to avoid data/task skew.

### DIFF
--- a/oap-ape/ape-java/ape-spark/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetNativeRecordReaderWrapper.java
+++ b/oap-ape/ape-java/ape-spark/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetNativeRecordReaderWrapper.java
@@ -109,7 +109,9 @@ public class ParquetNativeRecordReaderWrapper extends RecordReader<Void, Object>
 
     boolean flag = false;
     for (BlockMetaData blockMetaData : blocks) {
-      if (splitStart <= currentOffset && splitStart + splitSize >= currentOffset) {
+      // check mid point rather than start point to avoid data/task skew.
+      if (splitStart <= currentOffset + blockMetaData.getCompressedSize() / 2 &&
+          splitStart + splitSize >= currentOffset + blockMetaData.getCompressedSize() / 2) {
         if (!flag) {
           flag = true;
           inputSplitRowGroupStartIndex = rowGroupIndex;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, if a split file contains the start point of a row group, this row group will assign to this task. However, this behavior may lead to data skew, some tasks will consume nothing. So we need to check mid point rather than start point.


## How was this patch tested?

manual tests

