### PR TITLE
[SQL-DS-CACHE-107][POAE7-1098] wrap remote APE service for Flink

### DIFF
--- a/oap-ape/ape-java/ape-common/src/main/java/com/intel/ape/service/params/ParquetReaderInitParams.java
+++ b/oap-ape/ape-java/ape-common/src/main/java/com/intel/ape/service/params/ParquetReaderInitParams.java
@@ -213,7 +213,7 @@ public class ParquetReaderInitParams implements Serializable {
         private int redisPort;
         private String redisPassword;
 
-        CacheLocalityStorage(String redisHost, int redisPort, String redisPassword) {
+        public CacheLocalityStorage(String redisHost, int redisPort, String redisPassword) {
             this.redisHost = redisHost;
             this.redisPort = redisPort;
             this.redisPassword = redisPassword;

--- a/oap-ape/ape-java/ape-flink/pom.xml
+++ b/oap-ape/ape-java/ape-flink/pom.xml
@@ -219,9 +219,11 @@
                       <include>com.intel.oap:pmem-common</include>
                       <include>com.intel.oap:ape-common</include>
                       <include>com.intel.oap:ape-hcfs</include>
+                      <include>com.intel.oap:ape-client</include>
                       <include>com.fasterxml.jackson.core:jackson-core</include>
                       <include>com.fasterxml.jackson.core:jackson-annotations</include>
                       <include>com.fasterxml.jackson.core:jackson-databind</include>
+                      <include>io.netty:netty-all</include>
                     </includes>
                   </artifactSet>
                   <relocations>

--- a/oap-ape/ape-java/ape-flink/pom.xml
+++ b/oap-ape/ape-java/ape-flink/pom.xml
@@ -59,6 +59,13 @@
 
     <dependency>
       <groupId>com.intel.oap</groupId>
+      <artifactId>ape-client</artifactId>
+      <version>${ape.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.intel.oap</groupId>
       <artifactId>ape-hcfs</artifactId>
       <version>${ape.version}</version>
     </dependency>

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/utils/ParquetRecordReaderWrapper.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/utils/ParquetRecordReaderWrapper.java
@@ -18,14 +18,14 @@
 
 package org.apache.flink.formats.parquet.utils;
 
+import java.io.IOException;
+
 import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.table.data.vector.writable.WritableColumnVector;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.schema.MessageType;
-
-import java.io.IOException;
 
 /**
  * Common API of APE reader wrappers.

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/utils/ParquetRecordReaderWrapper.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/utils/ParquetRecordReaderWrapper.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.utils;
+
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.table.data.vector.writable.WritableColumnVector;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.schema.MessageType;
+
+import java.io.IOException;
+
+/**
+ * Common API of APE reader wrappers.
+ */
+public interface ParquetRecordReaderWrapper {
+    void initialize(
+            Configuration hadoopConfig,
+            RowType projectedType,
+            FileSourceSplit split,
+            FilterPredicate filterPredicate,
+            String aggStr) throws IOException;
+
+    WritableColumnVector[] initBatch(
+            MessageType requestSchema,
+            int batchSize,
+            RowType projectedType);
+
+    boolean nextBatch(WritableColumnVector[] columns);
+
+    boolean skipNextRowGroup();
+
+    int getRowsRead();
+
+    void close();
+}

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/utils/ParquetRemoteRecordReaderWrapper.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/utils/ParquetRemoteRecordReaderWrapper.java
@@ -1,0 +1,442 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.utils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.intel.ape.service.netty.NettyMessage;
+import com.intel.ape.service.params.ParquetReaderInitParams;
+import com.intel.ape.util.ParquetFilterPredicateConvertor;
+import com.intel.oap.ape.service.netty.NettyParquetRequestHelper;
+import com.intel.oap.ape.service.netty.client.ParquetDataRequestClient;
+import com.intel.oap.fs.hadoop.ape.hcfs.Constants;
+
+import io.netty.buffer.ByteBuf;
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.formats.parquet.vector.remotevector.AbstractRemoteVector;
+import org.apache.flink.formats.parquet.vector.remotevector.RemoteBooleanVector;
+import org.apache.flink.formats.parquet.vector.remotevector.RemoteBytesVector;
+import org.apache.flink.formats.parquet.vector.remotevector.RemoteDoubleVector;
+import org.apache.flink.formats.parquet.vector.remotevector.RemoteFixedBytesVector;
+import org.apache.flink.formats.parquet.vector.remotevector.RemoteFloatVector;
+import org.apache.flink.formats.parquet.vector.remotevector.RemoteIntVector;
+import org.apache.flink.formats.parquet.vector.remotevector.RemoteLongVector;
+import org.apache.flink.table.data.DecimalDataUtils;
+import org.apache.flink.table.data.vector.writable.WritableColumnVector;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.parquet.Preconditions.checkArgument;
+
+/**
+ * Wrapper class for parquet data loading from remote servers.
+ */
+public class ParquetRemoteRecordReaderWrapper {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(ParquetRemoteRecordReaderWrapper.class);
+
+    private final int batchSize;
+    private int rowsRead;
+
+    private boolean isAggregatePushedDown = false;
+
+    private NettyParquetRequestHelper parquetRequestHelper;
+    private ParquetDataRequestClient requestClient;
+    private Map<Integer, NettyMessage.ReadBatchResponse> responses;
+
+    public ParquetRemoteRecordReaderWrapper(int batchSize) {
+        this.batchSize = batchSize;
+        responses = new HashMap<>();
+    }
+
+    public void initialize(
+            Configuration hadoopConfig,
+            RowType projectedType,
+            FileSourceSplit split,
+            FilterPredicate filterPredicate,
+            String aggStr) throws IOException, InterruptedException {
+
+        // get required row groups
+        ParquetUtils.RequiredRowGroups requiredRowGroups =
+                ParquetUtils.getRequiredSplitRowGroups(split, hadoopConfig);
+
+        // get hdfs file info
+        final Path filePath = split.path();
+        final String fileName = filePath.toUri().getRawPath();
+        // this string is like hdfs://host:port
+        final String hdfs = hadoopConfig.get("fs.defaultFS");
+        String[] res = hdfs.split(":");
+        String hdfsHost = filePath.toUri().getHost() != null ?
+                filePath.toUri().getHost() : res[1].substring(2);
+        int hdfsPort = filePath.toUri().getPort() != -1 ?
+                filePath.toUri().getPort() : Integer.parseInt(res[2]);
+
+        // get required columns
+        List<String> projectedFields = projectedType.getFieldNames();
+        List<String> fieldTypeList = new ArrayList<String>();
+        LogicalType[] projectedTypes = projectedType.getChildren().toArray(new LogicalType[0]);
+        for (LogicalType type : projectedTypes) {
+            fieldTypeList.add(type.getTypeRoot().name());
+        }
+
+        // schema in json format
+        String jsonSchema = new ConvertToJson(fieldTypeList, projectedFields).toJson();
+
+        // cache configuration
+        boolean plasmaCacheEnabled =
+                hadoopConfig.getBoolean("fs.ape.reader.plasmaCacheEnabled", false);
+        boolean plasmaCacheAsync =
+                hadoopConfig.getBoolean("fs.ape.reader.plasmaCacheAsync", false);
+        boolean preBufferEnabled =
+                hadoopConfig.getBoolean("fs.ape.reader.preBufferEnabled", false);
+        boolean cacheLocalityEnabled =
+                hadoopConfig.getBoolean("fs.ape.reader.cacheLocalityEnabled", false);
+
+        // parse type lengths in requested schema
+        List<Integer> typeSizes = new ArrayList<>();
+        List<Boolean> variableLengthFlags = new ArrayList<>();
+        parseRequestedTypeLengths(projectedType, typeSizes, variableLengthFlags);
+
+        // build params for remote parquet reader
+        ParquetReaderInitParams params = new ParquetReaderInitParams(
+                fileName,
+                hdfsHost,
+                hdfsPort,
+                jsonSchema,
+                requiredRowGroups.getStartIndex(),
+                requiredRowGroups.getNumber(),
+                typeSizes,
+                variableLengthFlags,
+                batchSize,
+                plasmaCacheEnabled,
+                preBufferEnabled,
+                plasmaCacheAsync
+        );
+
+        // set cache locality
+        ParquetReaderInitParams.CacheLocalityStorage cacheLocalityStorage;
+        if (cacheLocalityEnabled) {
+            cacheLocalityStorage = new ParquetReaderInitParams.CacheLocalityStorage(
+                    hadoopConfig.get(Constants.CONF_KEY_FS_APE_HCFS_REDIS_HOST,
+                            Constants.DEFAULT_REDIS_HOST),
+                    hadoopConfig.getInt(Constants.CONF_KEY_FS_APE_HCFS_REDIS_PORT,
+                            Constants.DEFAULT_REDIS_PORT),
+                    hadoopConfig.get(Constants.CONF_KEY_FS_APE_HCFS_REDIS_AUTH,
+                            Constants.DEFAULT_REDIS_AUTH)
+            );
+            params.setCacheLocalityStorage(cacheLocalityStorage);
+        }
+
+        // push down filters
+        if (filterPredicate != null) {
+            String predicateStr = ParquetFilterPredicateConvertor.toJsonString(filterPredicate);
+            params.setFilterPredicate(predicateStr);
+        }
+
+        // push down aggregates
+        if (aggStr != null) {
+            params.setAggregateExpression(aggStr);
+            isAggregatePushedDown = true;
+        }
+
+        // create request client
+        parquetRequestHelper = new NettyParquetRequestHelper(hadoopConfig);
+        org.apache.hadoop.fs.Path file = new org.apache.hadoop.fs.Path(split.path().toUri());
+        requestClient = parquetRequestHelper.createRequestClient(
+                file, split.offset(), split.length());
+        requestClient.initRemoteParquetReader(params);
+
+        LOG.info("remote parquet reader initialized, plasma cache: {},  "
+                        + "cache locality: {}, pre buffer: {}",
+                plasmaCacheEnabled, cacheLocalityEnabled, preBufferEnabled);
+    }
+
+    private void parseRequestedTypeLengths(
+            RowType projectedType,
+            List<Integer> typeSizes,
+            List<Boolean> variableLengthFlags) {
+        for (int i = 0; i < projectedType.getFieldCount(); i++) {
+            LogicalType fieldType = projectedType.getTypeAt(i);
+            int typeSize = 1;
+            switch (fieldType.getTypeRoot()) {
+                case BOOLEAN:
+                    typeSizes.add(typeSize);
+                    variableLengthFlags.add(false);
+                    break;
+                case DATE:
+                case SMALLINT:
+                case INTEGER:
+                case TIME_WITHOUT_TIME_ZONE:
+                case FLOAT:
+                    typeSize = 4;
+                    typeSizes.add(typeSize);
+                    variableLengthFlags.add(false);
+                    break;
+                case BIGINT:
+                case DOUBLE:
+                    typeSize = 8;
+                    typeSizes.add(typeSize);
+                    variableLengthFlags.add(false);
+                    break;
+                case CHAR:
+                case VARCHAR:
+                case BINARY:
+                case VARBINARY:
+                    typeSize = 16;
+                    typeSizes.add(typeSize);
+                    variableLengthFlags.add(true);
+                    break;
+                case DECIMAL:
+                    DecimalType decimalType = (DecimalType) fieldType;
+                    if (DecimalDataUtils.is32BitDecimal(decimalType.getPrecision())) {
+                        typeSize = 4;
+                        typeSizes.add(typeSize);
+                        variableLengthFlags.add(false);
+                    } else if (DecimalDataUtils.is64BitDecimal(decimalType.getPrecision())) {
+                        typeSize = 8;
+                        typeSizes.add(typeSize);
+                        variableLengthFlags.add(false);
+                    } else {
+                        typeSize = 16;
+                        typeSizes.add(typeSize);
+                        variableLengthFlags.add(false);
+                    }
+                    break;
+                case TIMESTAMP_WITHOUT_TIME_ZONE:
+                case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                default:
+                    throw new UnsupportedOperationException(fieldType + " is not supported now.");
+            }
+        }
+    }
+
+    public WritableColumnVector[] initBatch(
+            MessageType requestSchema, int batchSize, RowType projectedType) {
+        WritableColumnVector[] columns = new WritableColumnVector[projectedType.getFieldCount()];
+
+        for (int i = 0; i < projectedType.getFieldCount(); i++) {
+            PrimitiveType primitiveType = null;
+            PrimitiveType.PrimitiveTypeName typeName = null;
+
+            // will not check types in schemas of file and request when aggregates are pushed down
+            if (!isAggregatePushedDown) {
+                primitiveType = requestSchema.getColumns().get(i).getPrimitiveType();
+                typeName = primitiveType.getPrimitiveTypeName();
+            }
+            LogicalType fieldType = projectedType.getTypeAt(i);
+
+            int typeSize = 1;
+            switch (fieldType.getTypeRoot()) {
+                case BOOLEAN:
+                    checkArgument(typeName == null ||
+                                    typeName == PrimitiveType.PrimitiveTypeName.BOOLEAN,
+                            "Unexpected type: %s", typeName);
+                    RemoteBooleanVector booleanVector =
+                            new RemoteBooleanVector(batchSize, typeSize);
+                    columns[i] = booleanVector;
+                    break;
+                case DATE:
+                case SMALLINT:
+                case INTEGER:
+                case TIME_WITHOUT_TIME_ZONE:
+                    checkArgument(typeName == null ||
+                                    typeName == PrimitiveType.PrimitiveTypeName.INT32,
+                            "Unexpected type: %s", typeName);
+                    typeSize = 4;
+                    RemoteIntVector intVector = new RemoteIntVector(batchSize, typeSize);
+                    columns[i] = intVector;
+                    break;
+                case BIGINT:
+                    checkArgument(typeName == null ||
+                                    typeName == PrimitiveType.PrimitiveTypeName.INT64,
+                            "Unexpected type: %s", typeName);
+                    typeSize = 8;
+                    RemoteLongVector longVector = new RemoteLongVector(batchSize, typeSize);
+                    columns[i] = longVector;
+                    break;
+                case FLOAT:
+                    checkArgument(typeName == null ||
+                                    typeName == PrimitiveType.PrimitiveTypeName.FLOAT,
+                            "Unexpected type: %s", typeName);
+                    typeSize = 4;
+                    RemoteFloatVector floatVector = new RemoteFloatVector(batchSize, typeSize);
+                    columns[i] = floatVector;
+                    break;
+                case DOUBLE:
+                    checkArgument(typeName == null ||
+                                    typeName == PrimitiveType.PrimitiveTypeName.DOUBLE,
+                            "Unexpected type: %s", typeName);
+                    typeSize = 8;
+                    RemoteDoubleVector doubleVector = new RemoteDoubleVector(batchSize, typeSize);
+                    columns[i] = doubleVector;
+                    break;
+                case CHAR:
+                case VARCHAR:
+                case BINARY:
+                case VARBINARY:
+                    checkArgument(typeName == null ||
+                                    typeName == PrimitiveType.PrimitiveTypeName.BINARY,
+                            "Unexpected type: %s", typeName);
+                    typeSize = 16;
+                    RemoteBytesVector bytesVector = new RemoteBytesVector(batchSize, typeSize);
+                    columns[i] = bytesVector;
+                    break;
+                case DECIMAL:
+                    DecimalType decimalType = (DecimalType) fieldType;
+                    if (DecimalDataUtils.is32BitDecimal(decimalType.getPrecision())) {
+                        checkArgument(
+                            (typeName == null
+                                || typeName == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY
+                                || typeName == PrimitiveType.PrimitiveTypeName.INT32
+                            ) && (primitiveType == null
+                                || primitiveType.getOriginalType() == OriginalType.DECIMAL
+                            ),
+                            "Unexpected type: %s", typeName);
+                        typeSize = 4;
+                        RemoteIntVector decimal32Vector = new RemoteIntVector(batchSize, typeSize);
+                        columns[i] = decimal32Vector;
+                    } else if (DecimalDataUtils.is64BitDecimal(decimalType.getPrecision())) {
+                        checkArgument(
+                            (typeName == null
+                                || typeName == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY
+                                || typeName == PrimitiveType.PrimitiveTypeName.INT64
+                            ) && (primitiveType == null
+                                || primitiveType.getOriginalType() == OriginalType.DECIMAL
+                            ),
+                            "Unexpected type: %s", typeName);
+
+                        typeSize = 8;
+                        RemoteLongVector decimal64Vector =
+                                new RemoteLongVector(batchSize, typeSize);
+                        columns[i] = decimal64Vector;
+                    } else {
+                        typeSize = 16;
+                        RemoteFixedBytesVector decimalBytesVector =
+                                new RemoteFixedBytesVector(batchSize, typeSize);
+                        columns[i] = decimalBytesVector;
+                    }
+                    break;
+                case TIMESTAMP_WITHOUT_TIME_ZONE:
+                case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                default:
+                    throw new UnsupportedOperationException(fieldType + " is not supported now.");
+            }
+        }
+        return columns;
+    }
+
+    public boolean nextBatch(WritableColumnVector[] columns) {
+        if (requestClient == null) {
+            return false;
+        }
+
+        // release buffers in used response
+        int trackingId = ((AbstractRemoteVector) columns[0]).getTrackingId();
+        if (trackingId > 0) {
+            NettyMessage.ReadBatchResponse response = responses.remove(trackingId);
+            response.releaseBuffers();
+        }
+
+        // read next batch
+        try {
+            NettyMessage.ReadBatchResponse response = requestClient.nextBatch();
+            int batchSequenceId = response.getSequenceId();
+            responses.put(batchSequenceId, response);
+            rowsRead = response.getRowCount();
+
+            // parse response data
+            for (int i = 0; i < columns.length; i++) {
+                WritableColumnVector column = columns[i];
+
+                if (column instanceof AbstractRemoteVector) {
+                    // check if column elements have variable lengths
+                    ByteBuf elementLengthBuf = null;
+                    if (response.getCompositeFlags()[i]) {
+                        // slice buffer of element lengths for current column
+                        elementLengthBuf = response.getCompositedElementLengths()
+                                .readRetainedSlice(rowsRead * 4);
+                    }
+
+                    // set data into vector
+                    AbstractRemoteVector remoteVector = ((AbstractRemoteVector) column);
+                    remoteVector.setTrackingId(batchSequenceId);
+                    remoteVector.setBuffers(
+                            response.getDataBuffers()[i],
+                            response.getNullBuffers()[i],
+                            elementLengthBuf
+                    );
+                } else {
+                    throw new RuntimeException(
+                            "Invalid invoke of nextBatch on non-remote vectors.");
+                }
+            }
+
+            return rowsRead > 0 || response.hasNextBatch();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public boolean skipNextRowGroup() {
+        try {
+            requestClient.skipNextRowGroup();
+            return true;
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public int getRowsRead() {
+        return rowsRead;
+    }
+
+    public void close() {
+        try {
+            if (requestClient != null) {
+                requestClient.close();
+            }
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            if (parquetRequestHelper != null) {
+                parquetRequestHelper.shutdownNettyClient();
+            }
+        }
+
+        for (NettyMessage.ReadBatchResponse response: responses.values()) {
+            response.releaseBuffers();
+        }
+        responses.clear();
+
+    }
+}

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/utils/ParquetUtils.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/utils/ParquetUtils.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.format.ColumnChunk;
+import org.apache.parquet.format.ColumnMetaData;
+import org.apache.parquet.format.FileMetaData;
+import org.apache.parquet.format.RowGroup;
+import org.apache.parquet.hadoop.util.HadoopInputFile;
+import org.apache.parquet.io.SeekableInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.parquet.bytes.BytesUtils.readIntLittleEndian;
+import static org.apache.parquet.format.Util.readFileMetaData;
+import static org.apache.parquet.hadoop.ParquetFileWriter.MAGIC;
+
+/**
+ * Utility functions for parquet file metadata.
+ */
+public class ParquetUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(ParquetUtils.class);
+
+    public static class RequiredRowGroups {
+        private int startIndex = 0;
+        private int number = 0;
+
+        public int getStartIndex() {
+            return startIndex;
+        }
+
+        public void setStartIndex(int startIndex) {
+            this.startIndex = startIndex;
+        }
+
+        public int getNumber() {
+            return number;
+        }
+
+        public void setNumber(int number) {
+            this.number = number;
+        }
+    }
+
+    // get required row groups for a task split.
+    public static RequiredRowGroups getRequiredSplitRowGroups(
+            FileSourceSplit split, Configuration configuration) throws IOException {
+
+        long splitStart = split.offset();
+        long splitSize = split.length();
+        InputStream footerBytesStream = getFooterBytesStream(split, configuration);
+
+        RequiredRowGroups ret = filterRowGroupsByMidpoint(
+                readFileMetaData(footerBytesStream),
+                splitStart,
+                splitStart + splitSize);
+        footerBytesStream.close();
+
+        return ret;
+    }
+
+    private static InputStream getFooterBytesStream(
+            FileSourceSplit split, Configuration configuration) throws IOException {
+
+        org.apache.hadoop.fs.Path file = new org.apache.hadoop.fs.Path(split.path().toUri());
+        HadoopInputFile inputFile = HadoopInputFile.fromPath(file, configuration);
+
+        SeekableInputStream f = inputFile.newStream();
+        long fileLen = inputFile.getLength();
+
+        int FOOTER_LENGTH_SIZE = 4;
+        if (fileLen < MAGIC.length + FOOTER_LENGTH_SIZE + MAGIC.length) {
+            // MAGIC + data + footer + footerIndex + MAGIC
+            throw new RuntimeException(file.toString() +
+                    " is not a Parquet file (too small length: " + fileLen + ")");
+        }
+
+        long footerLengthIndex = fileLen - FOOTER_LENGTH_SIZE - MAGIC.length;
+
+        f.seek(footerLengthIndex);
+        int footerLength = readIntLittleEndian(f);
+        byte[] magic = new byte[MAGIC.length];
+        f.readFully(magic);
+
+        if (!Arrays.equals(MAGIC, magic)) {
+            throw new RuntimeException(file.toString() +
+                    " is not a Parquet file. expected magic number at tail "
+                    + Arrays.toString(MAGIC) + " but found " + Arrays.toString(magic));
+        }
+
+        long footerIndex = footerLengthIndex - footerLength;
+        LOG.debug("read footer length: {}, footer index: {}", footerLength, footerIndex);
+        if (footerIndex < MAGIC.length || footerIndex >= footerLengthIndex) {
+            throw new RuntimeException("corrupted file: the footer index is not within the file: "
+                    + footerIndex);
+        }
+
+        f.seek(footerIndex);
+        ByteBuffer footerBytesBuffer = ByteBuffer.allocate(footerLength);
+        f.readFully(footerBytesBuffer);
+        f.close();
+        LOG.debug("Finished to read all footer bytes.");
+
+        footerBytesBuffer.flip();
+        return ByteBufferInputStream.wrap(footerBytesBuffer);
+    }
+
+    private static RequiredRowGroups filterRowGroupsByMidpoint(
+            FileMetaData metaData, long startOffset, long endOffset) {
+
+        RequiredRowGroups ret = new RequiredRowGroups();
+
+        List<RowGroup> rowGroups = metaData.getRow_groups();
+        int inputIndex = 0;
+        boolean flag = false;
+        for (RowGroup rowGroup : rowGroups) {
+            long totalSize = 0;
+            long startIndex = getColumnOffset(rowGroup.getColumns().get(0));
+            for (ColumnChunk col : rowGroup.getColumns()) {
+                totalSize += col.getMeta_data().getTotal_compressed_size();
+            }
+            long midPoint = startIndex + totalSize / 2;
+
+            if (midPoint >= startOffset && midPoint < endOffset) {
+                if (!flag) {
+                    ret.startIndex = inputIndex;
+                    flag = true;
+                }
+                ret.number += 1;
+            }
+            inputIndex++;
+        }
+        LOG.info("Required row groups: start: {}, num: {}", ret.startIndex, ret.number);
+
+        return ret;
+    }
+
+    protected static long getColumnOffset(ColumnChunk columnChunk) {
+        ColumnMetaData md = columnChunk.getMeta_data();
+        long offset = md.getData_page_offset();
+        if (md.isSetDictionary_page_offset() && offset > md.getDictionary_page_offset()) {
+            offset = md.getDictionary_page_offset();
+        }
+        return offset;
+    }
+
+}

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/AbstractRemoteVector.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/AbstractRemoteVector.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.vector.remotevector;
+
+import io.netty.buffer.ByteBuf;
+
+import org.apache.flink.table.data.vector.writable.AbstractWritableVector;
+import org.apache.flink.table.data.vector.writable.WritableIntVector;
+
+public abstract class AbstractRemoteVector extends AbstractWritableVector {
+    protected final int vectorLength;
+    protected final int typeSize;
+
+    private int trackingId = 0; // tracking batch ID for resource recycling.
+
+    protected ByteBuf dataBuf;
+    protected ByteBuf nullBuf;
+
+    protected ByteBuf elementLengthBuf;
+
+    public AbstractRemoteVector(int vectorLength, int typeSize) {
+        this.vectorLength = vectorLength;
+        this.typeSize = typeSize;
+    }
+
+    public void setBuffers(ByteBuf dataBuf, ByteBuf nullBuf, ByteBuf elementLengthBuf) {
+        this.dataBuf = dataBuf;
+        this.nullBuf = nullBuf;
+        this.elementLengthBuf = elementLengthBuf;
+    }
+
+    public void setTrackingId(int id) {
+        trackingId = id;
+    }
+
+    public int getTrackingId() {
+        return trackingId;
+    }
+
+    @Override
+    public void reset() {
+        // Only element length buffer is sliced from batch response.
+        // Data buffer and null buffer will be released by response itself.
+        if (elementLengthBuf != null) {
+            elementLengthBuf.release();
+            elementLengthBuf = null;
+        }
+    }
+
+    @Override
+    public boolean isNullAt(int i) {
+        return !(nullBuf.getBoolean(i));
+    }
+
+    @Override
+    public void setNullAt(int i) {
+        nullBuf.setBoolean(i, false);
+    }
+
+    @Override
+    public void setNulls(int i, int i1) {
+        for (int j = 0; j < i1; j++) {
+            setNullAt(j);
+        }
+    }
+
+    @Override
+    public void fillWithNulls() {
+        for (int i = 0; i < nullBuf.readableBytes(); i++) {
+            setNullAt(i);
+        }
+    }
+
+    @Override
+    public WritableIntVector reserveDictionaryIds(int i) {
+        return null;
+    }
+
+    @Override
+    public WritableIntVector getDictionaryIds() {
+        return null;
+    }
+}

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteBooleanVector.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteBooleanVector.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.vector.remotevector;
+
+import org.apache.flink.table.data.vector.writable.WritableBooleanVector;
+
+public class RemoteBooleanVector extends AbstractRemoteVector implements WritableBooleanVector {
+
+    public RemoteBooleanVector(int len, int typeSize) {
+        super(len, typeSize);
+    }
+
+    @Override
+    public void setBoolean(int i, boolean b) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public void fill(boolean b) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public boolean getBoolean(int i) {
+        return dataBuf.getBoolean(i);
+    }
+}

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteByteVector.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteByteVector.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.vector.remotevector;
+
+import org.apache.flink.table.data.vector.writable.WritableByteVector;
+
+public class RemoteByteVector extends AbstractRemoteVector implements WritableByteVector {
+    public RemoteByteVector(int vectorLength, int typeSize) {
+        super(vectorLength, typeSize);
+    }
+
+    @Override
+    public void setByte(int i, byte b) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public void fill(byte b) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public byte getByte(int i) {
+        return dataBuf.getByte(i);
+    }
+}

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteBytesVector.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteBytesVector.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.vector.remotevector;
+
+import io.netty.buffer.ByteBuf;
+import org.apache.flink.table.data.vector.writable.WritableBytesVector;
+
+public class RemoteBytesVector extends AbstractRemoteVector implements WritableBytesVector {
+    private final int[] sizes;
+    private final int[] offsets;
+
+    public RemoteBytesVector(int len, int typeSize) {
+        super(len, typeSize);
+        sizes = new int[len];
+        offsets = new int[len];
+    }
+
+    @Override
+    public void setBuffers(ByteBuf dataBuf, ByteBuf nullBuf, ByteBuf elementLengthBuf) {
+        super.setBuffers(dataBuf, nullBuf, elementLengthBuf);
+
+        int i = 0;
+        int cur = 0;
+        while (elementLengthBuf.isReadable()) {
+            int size = elementLengthBuf.readInt();
+
+            sizes[i] = size;
+            offsets[i] = cur;
+
+            cur += size;
+            i++;
+        }
+    }
+
+    @Override
+    public void appendBytes(int i, byte[] bytes, int i1, int i2) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public void fill(byte[] bytes) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public Bytes getBytes(int i) {
+        byte[] str = new byte[sizes[i]];
+        dataBuf.getBytes(offsets[i], str);
+        return new Bytes(str, 0, str.length);
+    }
+}

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteBytesVector.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteBytesVector.java
@@ -38,7 +38,7 @@ public class RemoteBytesVector extends AbstractRemoteVector implements WritableB
         int i = 0;
         int cur = 0;
         while (elementLengthBuf.isReadable()) {
-            int size = elementLengthBuf.readInt();
+            int size = elementLengthBuf.readIntLE();
 
             sizes[i] = size;
             offsets[i] = cur;

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteDoubleVector.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteDoubleVector.java
@@ -42,6 +42,6 @@ public class RemoteDoubleVector extends AbstractRemoteVector implements Writable
 
     @Override
     public double getDouble(int i) {
-        return dataBuf.getDouble(i * typeSize);
+        return dataBuf.getDoubleLE(i * typeSize);
     }
 }

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteDoubleVector.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteDoubleVector.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.vector.remotevector;
+
+import org.apache.flink.table.data.vector.writable.WritableDoubleVector;
+
+public class RemoteDoubleVector extends AbstractRemoteVector implements WritableDoubleVector {
+    public RemoteDoubleVector(int vectorLength, int typeSize) {
+        super(vectorLength, typeSize);
+    }
+
+    @Override
+    public void setDouble(int i, double v) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public void setDoublesFromBinary(int i, int i1, byte[] bytes, int i2) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public void fill(double v) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public double getDouble(int i) {
+        return dataBuf.getDouble(i * typeSize);
+    }
+}

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteFixedBytesVector.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteFixedBytesVector.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.vector.remotevector;
+
+import org.apache.flink.table.data.vector.writable.WritableBytesVector;
+
+public class RemoteFixedBytesVector extends AbstractRemoteVector implements WritableBytesVector {
+    public RemoteFixedBytesVector(int vectorLength, int typeSize) {
+        super(vectorLength, typeSize);
+    }
+
+    @Override
+    public void appendBytes(int i, byte[] bytes, int i1, int i2) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public void fill(byte[] bytes) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public Bytes getBytes(int i) {
+        byte[] str = new byte[typeSize];
+        dataBuf.getBytes(i * typeSize, str);
+        return new Bytes(str, 0, str.length);
+    }
+}

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteFloatVector.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteFloatVector.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.vector.remotevector;
+
+import org.apache.flink.table.data.vector.writable.WritableFloatVector;
+
+public class RemoteFloatVector extends AbstractRemoteVector implements WritableFloatVector {
+    public RemoteFloatVector(int vectorLength, int typeSize) {
+        super(vectorLength, typeSize);
+    }
+
+    @Override
+    public void setFloat(int i, float v) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public void setFloatsFromBinary(int i, int i1, byte[] bytes, int i2) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public void fill(float v) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public float getFloat(int i) {
+        return dataBuf.getFloat(i * typeSize);
+    }
+}

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteFloatVector.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteFloatVector.java
@@ -42,6 +42,6 @@ public class RemoteFloatVector extends AbstractRemoteVector implements WritableF
 
     @Override
     public float getFloat(int i) {
-        return dataBuf.getFloat(i * typeSize);
+        return dataBuf.getFloatLE(i * typeSize);
     }
 }

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteIntVector.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteIntVector.java
@@ -52,6 +52,6 @@ public class RemoteIntVector extends AbstractRemoteVector implements WritableInt
 
     @Override
     public int getInt(int i) {
-        return dataBuf.getInt(i * typeSize);
+        return dataBuf.getIntLE(i * typeSize);
     }
 }

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteIntVector.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteIntVector.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.vector.remotevector;
+
+import org.apache.flink.table.data.vector.writable.WritableIntVector;
+
+public class RemoteIntVector extends AbstractRemoteVector implements WritableIntVector {
+    public RemoteIntVector(int vectorLength, int typeSize) {
+        super(vectorLength, typeSize);
+    }
+
+    @Override
+    public void setInt(int i, int i1) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public void setIntsFromBinary(int i, int i1, byte[] bytes, int i2) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public void setInts(int i, int i1, int i2) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public void setInts(int i, int i1, int[] ints, int i2) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public void fill(int i) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public int getInt(int i) {
+        return dataBuf.getInt(i * typeSize);
+    }
+}

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteLongVector.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteLongVector.java
@@ -42,6 +42,6 @@ public class RemoteLongVector extends AbstractRemoteVector implements WritableLo
 
     @Override
     public long getLong(int i) {
-        return dataBuf.getLong(i * typeSize);
+        return dataBuf.getLongLE(i * typeSize);
     }
 }

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteLongVector.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteLongVector.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.vector.remotevector;
+
+import org.apache.flink.table.data.vector.writable.WritableLongVector;
+
+public class RemoteLongVector extends AbstractRemoteVector implements WritableLongVector {
+    public RemoteLongVector(int vectorLength, int typeSize) {
+        super(vectorLength, typeSize);
+    }
+
+    @Override
+    public void setLong(int i, long l) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public void setLongsFromBinary(int i, int i1, byte[] bytes, int i2) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public void fill(long l) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public long getLong(int i) {
+        return dataBuf.getLong(i * typeSize);
+    }
+}

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteShortVector.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteShortVector.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.vector.remotevector;
+
+import org.apache.flink.table.data.vector.writable.WritableShortVector;
+
+public class RemoteShortVector extends AbstractRemoteVector implements WritableShortVector {
+    public RemoteShortVector(int vectorLength, int typeSize) {
+        super(vectorLength, typeSize);
+    }
+
+    @Override
+    public void setShort(int i, short i1) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public void fill(short i) {
+        // should not reach here in remote vectors
+    }
+
+    @Override
+    public short getShort(int i) {
+        return dataBuf.getShort(i * typeSize);
+    }
+}

--- a/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteShortVector.java
+++ b/oap-ape/ape-java/ape-flink/src/main/java/org/apache/flink/formats/parquet/vector/remotevector/RemoteShortVector.java
@@ -37,6 +37,6 @@ public class RemoteShortVector extends AbstractRemoteVector implements WritableS
 
     @Override
     public short getShort(int i) {
-        return dataBuf.getShort(i * typeSize);
+        return dataBuf.getShortLE(i * typeSize);
     }
 }

--- a/oap-ape/ape-java/ape-server/src/main/java/com/intel/oap/ape/service/netty/server/RequestHandler.java
+++ b/oap-ape/ape-java/ape-server/src/main/java/com/intel/oap/ape/service/netty/server/RequestHandler.java
@@ -61,7 +61,7 @@ public class RequestHandler extends SimpleChannelInboundHandler<NettyMessage> {
     protected void channelRead0(ChannelHandlerContext ctx, NettyMessage msg) throws Exception {
         try {
             Class<?> msgClazz = msg.getClass();
-            LOG.info("Received request: {}", msg.toString());
+            LOG.debug("Received request: {}", msg.toString());
 
             if (msgClazz == NettyMessage.ReadBatchRequest.class) {
                 NettyMessage.ReadBatchRequest request =
@@ -75,7 +75,7 @@ public class RequestHandler extends SimpleChannelInboundHandler<NettyMessage> {
                     ctx.writeAndFlush(response);
                     final long duration = (System.nanoTime() - start) / 1_000;
 
-                    LOG.info("Sending batch response takes: {} us, response: {}",
+                    LOG.debug("Sending batch response takes: {} us, response: {}",
                             duration, response);
 
                     batchCount--;
@@ -90,7 +90,7 @@ public class RequestHandler extends SimpleChannelInboundHandler<NettyMessage> {
                         new NettyMessage.BooleanResponse(
                                 true, NettyMessage.ParquetReaderInitRequest.ID);
                 ctx.writeAndFlush(response);
-                LOG.info("Sent reader init response: {}", response.toString());
+                LOG.debug("Sent reader init response: {}", response.toString());
             } else if (msgClazz == NettyMessage.CloseReaderRequest.class) {
                 handleCloseReader();
 
@@ -246,7 +246,7 @@ public class RequestHandler extends SimpleChannelInboundHandler<NettyMessage> {
         }
 
         final long duration = (System.nanoTime() - start) / 1_000;
-        LOG.info("Composing batch response takes: {} us.", duration);
+        LOG.debug("Composing batch response takes: {} us.", duration);
 
         return new NettyMessage.ReadBatchResponse(
                 sequenceId++,


### PR DESCRIPTION
## What changes were proposed in this pull request?

* add wrapper and new vector classes for remote APE data loading in `ape-flink`
* add common API of wrappers for Flink

## How was this patch tested?

manual tests
