### PR TITLE
[SQL-DS-CACHE-158][POAE7-1191] Fix APE filter pushdown issues

### DIFF
--- a/oap-ape/ape-java/ape-spark/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/oap-ape/ape-java/ape-spark/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -691,7 +691,7 @@ object SQLConf {
       .internal()
       .intConf
       .checkValue(threshold => threshold >= 0, "The threshold must not be negative.")
-      .createWithDefault(10)
+      .createWithDefault(20)
 
   val PARQUET_WRITE_LEGACY_FORMAT = buildConf("spark.sql.parquet.writeLegacyFormat")
     .doc("If true, data will be written in a way of Spark 1.4 and earlier. For example, decimal " +


### PR DESCRIPTION
## What changes were proposed in this pull request?

Q7: Spark didn't  add isNotNull judgement inside Or expression, we add it when optimize logical plan.

Q53: in clause have more than 10 items, default rule and config will convert  up to 10 items to equal, and  it will lose filter if over this limit if combined ape. We make a workaround by modifying the default value


## How was this patch tested?

TPC-DS q7,q53

