### PR TITLE
[SQL-DS-CACHE-181][SDLe]Fix Snyk code scan issues

### DIFF
--- a/HCFS-based-cache/pom.xml
+++ b/HCFS-based-cache/pom.xml
@@ -27,7 +27,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <hadoop.version>3.3.0</hadoop.version>
+    <hadoop.version>3.3.1</hadoop.version>
   </properties>
 
   <dependencies>

--- a/Plasma-based-cache/pom.xml
+++ b/Plasma-based-cache/pom.xml
@@ -206,7 +206,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
-      <version>2.10.0</version>
+      <version>2.12.4</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump Hadoop version of HCFS-SQL-DS-Cache to 3.3.1
Bump jackson-module-scala-2.12 version to 2.12.4


## How was this patch tested?

Pass the Snyk scan.

